### PR TITLE
security(password): increase minimum length to 12 characters

### DIFF
--- a/internal/core/domain/errors.go
+++ b/internal/core/domain/errors.go
@@ -7,5 +7,6 @@ var (
 	ErrUserAlreadyExists  = errors.New("user already exists")
 	ErrUserNotFound       = errors.New("user not found")
 	ErrInvalidEmail       = errors.New("invalid email format")
-	ErrWeakPassword       = errors.New("password must be at least 8 characters long")
+	ErrWeakPassword       = errors.New("password must be at least 12 characters long")
+	ErrPasswordTooLong    = errors.New("password must not exceed 128 characters")
 )

--- a/internal/core/domain/password.go
+++ b/internal/core/domain/password.go
@@ -1,5 +1,12 @@
 package domain
 
+const (
+	// MinPasswordLength is the minimum allowed password length (NIST 800-63B recommendation)
+	MinPasswordLength = 12
+	// MaxPasswordLength is the maximum allowed password length to prevent DoS attacks
+	MaxPasswordLength = 128
+)
+
 // Password is a value object for a raw (unhashed) password.
 // It enforces minimum strength requirements before hashing.
 type Password struct {
@@ -8,8 +15,12 @@ type Password struct {
 
 // NewPassword validates a raw password and returns a Password value object.
 func NewPassword(raw string) (Password, error) {
-	if len(raw) < 8 {
+	if len(raw) < MinPasswordLength {
 		return Password{}, ErrWeakPassword
+	}
+
+	if len(raw) > MaxPasswordLength {
+		return Password{}, ErrPasswordTooLong
 	}
 
 	return Password{value: raw}, nil

--- a/internal/core/domain/password_test.go
+++ b/internal/core/domain/password_test.go
@@ -1,6 +1,7 @@
 package domain_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,11 +19,11 @@ func TestNewPassword(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name:  "valid password with exactly 8 characters",
-			input: "12345678",
+			name:  "valid password with exactly 12 characters",
+			input: "123456789abc",
 		},
 		{
-			name:  "valid password longer than 8 characters",
+			name:  "valid password longer than 12 characters",
 			input: "a-very-secure-passphrase",
 		},
 		{
@@ -30,14 +31,23 @@ func TestNewPassword(t *testing.T) {
 			input: "P@ssw0rd!#$%",
 		},
 		{
+			name:  "valid password with exactly 128 characters",
+			input: "a" + strings.Repeat("b", 126) + "c", // 128 chars
+		},
+		{
 			name:    "empty password",
 			input:   "",
 			wantErr: domain.ErrWeakPassword,
 		},
 		{
-			name:    "password with 7 characters — one below minimum",
-			input:   "1234567",
+			name:    "password with 11 characters — one below minimum",
+			input:   "123456789ab",
 			wantErr: domain.ErrWeakPassword,
+		},
+		{
+			name:    "password with 129 characters — exceeds maximum",
+			input:   strings.Repeat("a", 129),
+			wantErr: domain.ErrPasswordTooLong,
 		},
 	}
 


### PR DESCRIPTION
- Increase minimum password length from 8 to 12 characters (NIST 800-63B)
- Add maximum password length of 128 characters to prevent DoS
- Add constants MinPasswordLength and MaxPasswordLength for easy configuration
- Add new error ErrPasswordTooLong for maximum length validation
- Update tests to cover new boundary cases (128 and 129 characters)

All tests passing:
- internal/core/domain: 7/7 tests pass
- internal/core/services: 3/3 tests pass

Closes #3 